### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ WORKDIR ${omaha}
 ADD ./requirements/base.txt $omaha/requirements/base.txt
 
 RUN \
+  pip install --upgrade six
+    
+RUN \
   pip install paver --use-mirrors && \
   pip install -r requirements/base.txt --use-mirrors
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,8 +30,8 @@ RUN \
   pip install --upgrade six
     
 RUN \
-  pip install paver --use-mirrors && \
-  pip install -r requirements/base.txt --use-mirrors
+  pip install paver  && \
+  pip install -r requirements/base.txt 
 
 ADD . $omaha
 


### PR DESCRIPTION
We ran into a problem with the version of six that was installed with apt-get (1.5) and the version installed by pip (1.9) such that we were getting this error:

pkg_resources.VersionConflict: (six 1.5.2 (/usr/lib/python2.7/dist-packages), Requirement.parse('six>=1.9'))