### PR TITLE
Hide unused versions

### DIFF
--- a/omaha_server/omaha/statistics.py
+++ b/omaha_server/omaha/statistics.py
@@ -99,7 +99,7 @@ def get_users_versions(app_id):
     week = now.isocalendar()[1]
     versions = [str(v.version) for v in Version.objects.filter_by_enabled(app__id=app_id)]
     data = [(v, len(WeekEvents(event_name.format(app_id, v), now.year, week))) for v in versions]
-    return data
+    return filter(lambda x: x[1], data)
 
 
 @valuedispatch

--- a/omaha_server/omaha/tests/test_statistics.py
+++ b/omaha_server/omaha/tests/test_statistics.py
@@ -391,4 +391,4 @@ class GetStatisticsTest(TestCase):
     def test_get_users_versions(self):
         now = datetime.now()
         with freeze_time(datetime(year=now.year, month=now.month, day=10)):
-            self.assertListEqual(get_users_versions(self.app.id), [('1.0.0.0', now.month), ('2.0.0.0', 0)])
+            self.assertListEqual(get_users_versions(self.app.id), [('1.0.0.0', now.month)])


### PR DESCRIPTION
Hide unused versions on the statistics page