### PR TITLE
Several corrections in the documentation for HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ app:
 | AWS_ROLE                  |                    |                            |
 | OMAHA_URL_PREFIX          | no trailing slash! |                            |
 | SENTRY_STACKTRACE_API_KEY | Auth API token     |                            |
-| OMAHA_USE_SSL             | HTTPS-only         | False                      |
+| OMAHA_ONLY_HTTPS          | HTTPS-only         | False                      |
 
 - [uWSGI Options](http://uwsgi-docs.readthedocs.org/en/latest/Options.html) & [Environment variables](http://uwsgi-docs.readthedocs.org/en/latest/Configuration.html#environment-variables)
 - [Sentry](https://github.com/getsentry/sentry)
@@ -244,7 +244,7 @@ $ ebs-deploy init
 $ ebs-deploy deploy -e omaha-server-dev
 ```
 
-#### HTTPS
+#### Enable HTTPS
 
 1. [Add SSL Certificate for Elastic Load Balancing](https://github.com/Crystalnix/omaha-server/wiki/SSL-Certificate-for-Elastic-Load-Balancing)
 2. Next, just add the following snippet to your file `deploy/settings.yml`
@@ -256,7 +256,8 @@ $ ebs-deploy deploy -e omaha-server-dev
     LoadBalancerSSLPortProtocol: HTTPS
     SSLCertificateId: arn:aws:acm:us-east-1:your-ssl-id # ToDo: change on your SSL ID
   ```
-3. Finally, add environment variable `OMAHA_USE_SSL: true` to the *environment* section.
+3. Finally, in the case if you want to redirect all HTTP traffic to HTTPS, you can add `OMAHA_ONLY_HTTPS: true` to environment variables in the *environment* section.
+*Warning:* Please, don't activate the redirection of HTTP to HTTPS if you don't enable HTTPS. It will lead to that an Omaha server won't be accessible.
 
 ## Links
 

--- a/omaha_server/omaha_server/settings.py
+++ b/omaha_server/omaha_server/settings.py
@@ -20,7 +20,7 @@ PROJECT_DIR = BASE_DIR
 
 IS_PRIVATE = True if os.getenv('OMAHA_SERVER_PRIVATE', '').title() == 'True' else False
 
-if os.getenv('OMAHA_USE_SSL'):
+if os.getenv('OMAHA_ONLY_HTTPS'):
     SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
     SESSION_COOKIE_SECURE = True
     CSRF_COOKIE_SECURE = True


### PR DESCRIPTION
 - OMAHA_USE_SSL has been renamed to OMAHA_ONLY_HTTPS
 - The "HTTPS" section in README.md has been renamed to the "Enable HTTPS" and some additional details have been added.