### PR TITLE
Fix broken dependency django-debug-toolbar

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,7 +1,7 @@
 -r test.txt
 
 lxml==3.6.0
-django-debug-toolbar==1.4
+django-debug-toolbar==1.5
 django-debug-panel==0.8.2
 ebs-deploy==1.9.9
 bumpversion==0.5.3


### PR DESCRIPTION
Development dependency `django-debug-toolbar==1.4` had a dependency on an unspecified version of `sqlparse`. `sqlparse` was recently updated to a new version, which broke `django-debug-toolbar`. The problem manifested itself in `omaha-server` when creating the virtual environment from scratch. Updating `django-debug-toolbar` to 1.5 fixes the issue. See: http://stackoverflow.com/questions/38479063/django-debug-toolbar-breaking-on-admin-while-getting-sql-stats