### PR TITLE
Accelerate s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![Apache License, Version 2.0](https://img.shields.io/badge/license-Apache%202.0-red.svg)](https://github.com/Crystalnix/omaha-server/blob/master/LICENSE)
 [![](https://badge.imagelayers.io/crystalnix/omaha-server:master.svg)](https://imagelayers.io/?images=crystalnix/omaha-server:master 'Get your own badge on imagelayers.io')
 
-Google Omaha server implementation and Sparkle (mac) feed management. 
+Google Omaha server implementation and Sparkle (mac) feed management.
 
 Currently, our implementation is integrated into the updating processes of several organisations for products that require sophisticated update logic and advanced usage statistics. We provide additional support and further enhancement on a contract basis. For a case study and enquiries please refer [our website](http://crystalnix.com/works/google-omaha-server.html)
 
@@ -210,6 +210,7 @@ app:
 | AWS_ACCESS_KEY_ID         | AWS Access Key     |                            |
 | AWS_SECRET_ACCESS_KEY     | AWS Secret Key     |                            |
 | AWS_STORAGE_BUCKET_NAME   | S3 storage bucket  |                            |
+| AWS_S3_ACCELERATION       | S3 Transfer Accceleration | False                            |
 | RAVEN_DNS                 | Sentry url         |                            |
 | RAVEN_DSN_STACKTRACE      | Sentry url         | RAVEN_DNS                  |
 | REDIS_HOST                | Redis host         | 127.0.0.1                  |
@@ -231,7 +232,7 @@ app:
 
 - [uWSGI Options](http://uwsgi-docs.readthedocs.org/en/latest/Options.html) & [Environment variables](http://uwsgi-docs.readthedocs.org/en/latest/Configuration.html#environment-variables)
 - [Sentry](https://github.com/getsentry/sentry)
-- Sentry API key is stored on the way Sentry Organization page -> API Keys 
+- Sentry API key is stored on the way Sentry Organization page -> API Keys
 
 ### Initialize your ElasticBeanstalk application
 

--- a/omaha_server/omaha_server/settings_prod.py
+++ b/omaha_server/omaha_server/settings_prod.py
@@ -20,7 +20,9 @@ DEFAULT_FILE_STORAGE = 'omaha_server.s3utils.S3Storage'
 AWS_ACCESS_KEY_ID = os.environ.get('AWS_ACCESS_KEY_ID')
 AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_SECRET_ACCESS_KEY')
 AWS_STORAGE_BUCKET_NAME = os.environ.get('AWS_STORAGE_BUCKET_NAME')
-S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
+AWS_S3_ACCELERATION = (os.environ.get('AWS_S3_ACCELERATION'),'False')
+S3_URL_PREFIX = "s3-accelerate" if AWS_S3_ACCELERATION else "s3"
+S3_URL = 'https://%s.%s.amazonaws.com/' % (AWS_STORAGE_BUCKET_NAME , S3_URL_PREFIX)
 
 STATIC_URL = ''.join([S3_URL, 'static/'])
 AWS_PRELOAD_METADATA = True


### PR DESCRIPTION
**High-speed delivery on updates from Omaha can be improved!**
Amazon S3 Transfer Acceleration enables fast, easy, and secure transfers of files over long distances between your client and an S3 bucket. Transfer Acceleration takes advantage of Amazon CloudFront’s globally distributed edge locations. As the data arrives at an edge location, data is routed to Amazon S3 over an optimized network path.

**Enable turbocharged S3 transfer**
http://docs.aws.amazon.com/AmazonS3/latest/UG/enable-bucket-transfer-acceleration.html