### PR TITLE
Fix usage with update-engine

### DIFF
--- a/omaha_server/omaha/request.xsd
+++ b/omaha_server/omaha/request.xsd
@@ -46,6 +46,7 @@
             <xs:attribute name='shell_version' type='xs:string' use="optional"/>
             <xs:attribute name='periodoverridesec' type='xs:integer' use="optional"/>
             <xs:attribute name='dlpref' type='xs:string' use="optional"/>
+            <xs:anyAttribute namespace="##any" processContents="skip"/>
         </xs:complexType>
     </xs:element>
     <xs:element name="hw">

--- a/omaha_server/omaha/request.xsd
+++ b/omaha_server/omaha/request.xsd
@@ -13,13 +13,6 @@
             <xs:enumeration value="1"/>
         </xs:restriction>
     </xs:simpleType>
-    <xs:simpleType name="PlatformType">
-        <xs:restriction base="xs:string">
-            <xs:enumeration value="win"/>
-            <xs:enumeration value="mac"/>
-            <xs:enumeration value="ios"/>
-        </xs:restriction>
-    </xs:simpleType>
     <xs:simpleType name="ArchType">
         <xs:restriction base="xs:string">
             <xs:enumeration value="x86"/>
@@ -69,7 +62,7 @@
     </xs:element>
     <xs:element name='os'>
         <xs:complexType>
-            <xs:attribute name='platform' use='required' type='PlatformType'/>
+            <xs:attribute name='platform' use='required' type='xs:string'/>
             <xs:attribute name='version' use='required' type='xs:string'/>
             <xs:attribute name='sp' type="xs:string" use='required'/>
             <xs:attribute name='arch' use='required' type='xs:NCName'/>


### PR DESCRIPTION
First commit is just fixing the case where someone adds a new platform in omaha-server. win/mac is hardcoded several other places in the UI, but for now this works well enough. The second one is to losen the requirements on the XML a bit, update-engine likes to pass on several extra properties.

There's also some other smaller mismatches, like using «<app ap="foo" [...]» instead of «<request updaterchannel="foo" [...]», but fixing that in omaha-server was a bit more involved, so I'm just patching our version of update-engine instead for that for now.