### PR TITLE
Fix security bug(cookies)

### DIFF
--- a/omaha_server/omaha_server/settings.py
+++ b/omaha_server/omaha_server/settings.py
@@ -225,7 +225,6 @@ CACHES = {
     }
 }
 
-SESSION_ENGINE = 'django.contrib.sessions.backends.signed_cookies'
 SESSION_CACHE_ALIAS = 'default'
 
 STATICFILES_FINDERS = ("django.contrib.staticfiles.finders.FileSystemFinder",


### PR DESCRIPTION
Changed the way the session is stored. Before this session was stored in the cookie, it is now stored in the database. This is done so that when a user logout, the session is deleted. Because if you store the session in the cookie, the django does not expire the cookie immediately after the user logout. Catching a cookie by another user can remain in the system.