### PR TITLE
add logstah config file

### DIFF
--- a/conf/logstash.conf
+++ b/conf/logstash.conf
@@ -1,0 +1,35 @@
+input {
+  beats {
+    port => 5044
+    codec => "json"
+  }
+}
+
+filter {
+  mutate {
+    gsub => [
+      "message", "<.*>", ""
+    ]
+  }
+  kv { }
+  if [tags][json] {
+    json {
+      source => "message"
+    }
+  }
+}
+
+output {
+  elasticsearch {
+    hosts => "localhost:9200"
+    manage_template => true
+    index => "logstash-%{+YYYY.MM.dd}"
+    document_type => "%{[@metadata][type]}"
+  }
+}
+
+
+
+
+
+

--- a/omaha_server/crash/senders.py
+++ b/omaha_server/crash/senders.py
@@ -44,7 +44,11 @@ class ELKSender(BaseSender):
     def send(self, message, extra={}, tags={}, data={}, crash_obj=None):
         logger = logging.getLogger('crashes')
         extra.update(tags)
+        # sentry.interfaces.Exception
         extra.update(data)
+        extra.update({
+            'signature': message
+        })
         logger.info(add_extra_to_log_message(message, extra=extra))
 
 senders_dict = {


### PR DESCRIPTION
A new way of transferring the collected data to elasticsearch. Now the logstash is responsible for the delivery, this is done to make it easier to read and analyze logs