### PR TITLE
Update the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN \
   ln -s /srv/omaha/conf/nginx-app.conf /etc/nginx/sites-enabled/ && \
   ln -s /srv/omaha/conf/inflate_request.lua /etc/nginx/ && \
   ln -s /srv/omaha/conf/supervisord.conf /etc/supervisor/conf.d/ && \
-  ln -s /srv/omaha/conf/filebeat.yml /etc/filebeat/
+  ln -s /srv/omaha/conf/filebeat.yml /etc/filebeat/ && \
+  chmod go-w /etc/filebeat/filebeat.yml
 
 EXPOSE 80
 EXPOSE 8080


### PR DESCRIPTION
Filebeat was not started due to a problem with permission to the configuration file. I've updated the dockerfile so that permissions were set correctly.