### PR TITLE
Fix error with code 500

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -7,7 +7,7 @@ jsonfield==1.0.3
 boto==2.40.0
 django-storages==1.6.5
 django-absolute==0.3
-django-versionfield3==0.1.6
+django-versionfield3==0.1.8
 raven==5.17.0
 django-redis==4.4.3
 bitmapist==3.97


### PR DESCRIPTION
Incorrect version input causes 500 error. To fix the error, update the django-versionfield3 library.