### PR TITLE
Update psycopg2 library

### DIFF
--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -12,5 +12,5 @@ factory-boy==2.8.1
 mock==2.0.0
 tox==2.5.0
 pyquery==1.2.13
-psycopg2==2.6.1
+psycopg2==2.7.3.2
 moto==0.4.24


### PR DESCRIPTION
Travis updated the linux image. Because of this, the CI tests fall. Should update psycopg2 library.