### PR TITLE
Add log_nginx_to_filebeat variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,46 +196,48 @@ app:
 
 #### Environment variables
 
-| Environment variable name |    Description      |       Default value        |
-|---------------------------|---------------------|----------------------------|
-| APP_VERSION               | App version         | DEV                        |
-| DJANGO_SETTINGS_MODULE    |                     | omaha_server.settings_prod |
-| SECRET_KEY                | Django SECRET_KEY   |                            |
-| HOST_NAME                 | Eb app host name    |                            |
-| DB_HOST                   | DB Host             | 127.0.0.1                  |
-| DB_USER                   | DB User             | postgres                   |
-| DB_NAME                   | DB Name             | postgres                   |
-| DB_PASSWORD               | DB Password         | ''                         |
-| DB_PORT                   | DB port             | 5432                       |
-| AWS_ACCESS_KEY_ID         | AWS Access Key      |                            |
-| AWS_SECRET_ACCESS_KEY     | AWS Secret Key      |                            |
-| AWS_STORAGE_BUCKET_NAME   | S3 storage bucket   |                            |
-| RAVEN_DNS                 | Sentry url          |                            |
-| RAVEN_DSN_STACKTRACE      | Sentry url          | RAVEN_DNS                  |
-| REDIS_HOST                | Redis host          | 127.0.0.1                  |
-| REDIS_PORT                | Redis port          | 6379                       |
-| REDIS_DB                  | Redis db            | 1                          |
-| REDIS_STAT_PORT           | For statistics      | REDIS_PORT                 |
-| REDIS_STAT_HOST           |                     | REDIS_HOST                 |
-| REDIS_STAT_DB             |                     | 15                         |
-| UWSGI_PROCESSES           |                     |                            |
-| UWSGI_THREADS             |                     |                            |
-| OMAHA_SERVER_PRIVATE      | Is private server   | False                      |
-| DB_PUBLIC_USER            |                     |                            |
-| DB_PUBLIC_PASSWORD        |                     |                            |
-| AWS_ROLE                  |                     |                            |
-| OMAHA_URL_PREFIX          | no trailing slash!  |                            |
-| SENTRY_STACKTRACE_API_KEY | Auth API token      |                            |
-| OMAHA_ONLY_HTTPS          | HTTPS-only          | False                      |
-| CUP_REQUEST_VALIDATION    |                     | False                      |
-| CRASH_TRACKER             | Sentry, ELK         | Sentry                     |
-| LOGSTASH_HOST             | Logstash host       |                            |
-| LOGSTASH_PORT             | Logstash TCP port   |                            |
-| FILEBEAT_HOST             | Filebeat host       | 127.0.0.1                  |
-| FILEBEAT_PORT             | Filebeat UDP port   | 9021                       |
-| ELK_HOST                  | Logstash host       | ''                         |
-| ELK_PORT                  | Logstash TCP port   | ''                         |
-| FILEBEAT_DESTINATION      | filebeat output type| ''                         |
+| Environment variable name |    Description       |       Default value        |
+|---------------------------|----------------------|----------------------------|
+| APP_VERSION               | App version          | DEV                        |
+| DJANGO_SETTINGS_MODULE    |                      | omaha_server.settings_prod |
+| SECRET_KEY                | Django SECRET_KEY    |                            |
+| HOST_NAME                 | Eb app host name     |                            |
+| DB_HOST                   | DB Host              | 127.0.0.1                  |
+| DB_USER                   | DB User              | postgres                   |
+| DB_NAME                   | DB Name              | postgres                   |
+| DB_PASSWORD               | DB Password          | ''                         |
+| DB_PORT                   | DB port              | 5432                       |
+| AWS_ACCESS_KEY_ID         | AWS Access Key       |                            |
+| AWS_SECRET_ACCESS_KEY     | AWS Secret Key       |                            |
+| AWS_STORAGE_BUCKET_NAME   | S3 storage bucket    |                            |
+| RAVEN_DNS                 | Sentry url           |                            |
+| RAVEN_DSN_STACKTRACE      | Sentry url           | RAVEN_DNS                  |
+| REDIS_HOST                | Redis host           | 127.0.0.1                  |
+| REDIS_PORT                | Redis port           | 6379                       |
+| REDIS_DB                  | Redis db             | 1                          |
+| REDIS_STAT_PORT           | For statistics       | REDIS_PORT                 |
+| REDIS_STAT_HOST           |                      | REDIS_HOST                 |
+| REDIS_STAT_DB             |                      | 15                         |
+| UWSGI_PROCESSES           |                      |                            |
+| UWSGI_THREADS             |                      |                            |
+| OMAHA_SERVER_PRIVATE      | Is private server    | False                      |
+| DB_PUBLIC_USER            |                      |                            |
+| DB_PUBLIC_PASSWORD        |                      |                            |
+| AWS_ROLE                  |                      |                            |
+| OMAHA_URL_PREFIX          | no trailing slash!   |                            |
+| SENTRY_STACKTRACE_API_KEY | Auth API token       |                            |
+| OMAHA_ONLY_HTTPS          | HTTPS-only           | False                      |
+| CUP_REQUEST_VALIDATION    |                      | False                      |
+| CRASH_TRACKER             | Sentry, ELK          | Sentry                     |
+| LOGSTASH_HOST             | Logstash host        |                            |
+| LOGSTASH_PORT             | Logstash TCP port    |                            |
+| FILEBEAT_HOST             | Filebeat host        | 127.0.0.1                  |
+| FILEBEAT_PORT             | Filebeat UDP port    | 9021                       |
+| ELK_HOST                  | Logstash host        | ''                         |
+| ELK_PORT                  | Logstash TCP port    | ''                         |
+| FILEBEAT_DESTINATION      | filebeat output type | ''                         |
+| LOG_NGINX_TO_FILEBEAT     | Send logs to filebeat| 'True'                     |
+
 
 - [uWSGI Options](http://uwsgi-docs.readthedocs.org/en/latest/Options.html) & [Environment variables](http://uwsgi-docs.readthedocs.org/en/latest/Configuration.html#environment-variables)
 - [Sentry](https://github.com/getsentry/sentry)

--- a/pavement.py
+++ b/pavement.py
@@ -94,7 +94,8 @@ def create_admin():
 def configure_nginx():
     filebeat_host = os.environ.get('FILEBEAT_HOST', '')
     filebeat_port = os.environ.get('FILEBEAT_PORT', '')
-    if filebeat_host and filebeat_port.isdigit():
+    log_nginx_to_filebeat = True if os.environ.get('LOG_NGINX_TO_FILEBEAT', 'True').title() == 'True' else False
+    if log_nginx_to_filebeat and filebeat_host and filebeat_port.isdigit():
         sh("sed -i 's/access_log.*;/access_log syslog:server=%s:%s main;/g' /etc/nginx/nginx.conf" % (filebeat_host, filebeat_port))
         sh("sed -i 's/error_log.*;/error_log syslog:server=%s:%s;/g' /etc/nginx/nginx.conf" % (filebeat_host, filebeat_port))
     else:


### PR DESCRIPTION
A new variable is needed to disable sending NGINX logs to filebeat.