### PR TITLE
Update filebeat configure

### DIFF
--- a/conf/filebeat.yml
+++ b/conf/filebeat.yml
@@ -21,6 +21,12 @@ filebeat.prospectors:
 - type: udp
   host: "localhost:9021"
 
+processors:
+ - drop_event:
+     when:
+        regexp:
+           message: "/healthcheck/status/"
+
 #- type: log
 #  enabled: false
 
@@ -149,6 +155,7 @@ setup.kibana:
 output.elasticsearch:
   # Array of hosts to connect to.
   hosts: ["localhost:9200"]
+  pipeline: "standard_filter"
 
   # Optional protocol and basic auth credentials.
   #protocol: "https"

--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -39,7 +39,7 @@ http {
 	# Logging Settings
 	##
 
-	log_format   main '$remote_addr $remote_user [$time_local] hostname=$server_name $status '
+	log_format   main '$remote_addr $remote_user [$time_local] hostname is $server_name $status '
     '"$request" $body_bytes_sent "$http_referer" '
     '"$http_user_agent" ';
 	access_log /var/log/nginx/access.log main;

--- a/conf/standard_filter.json
+++ b/conf/standard_filter.json
@@ -1,0 +1,40 @@
+{
+  "description": "standard filter. You can modify it.",
+  "processors": [
+    {
+      "rename": {
+        "field": "message",
+        "target_field": "incoming_message"
+      }
+    },
+    {
+      "gsub": {
+        "field": "incoming_message",
+        "pattern": "<\\d+>",
+        "replacement": ""
+      }
+    },
+    {
+      "kv": {
+        "field": "incoming_message",
+        "field_split": "\\|",
+        "value_split": "=",
+        "ignore_missing": true,
+        "on_failure" : [
+          {
+            "rename" : {
+              "field" : "incoming_message",
+              "target_field" : "message"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "remove": {
+        "field": "incoming_message",
+        "ignore_failure": true
+      }
+    }
+  ]
+}

--- a/omaha_server/omaha_server/settings_prod.py
+++ b/omaha_server/omaha_server/settings_prod.py
@@ -67,8 +67,8 @@ LOGGING = {
         'verbose': {
             'format': '%(levelname)s %(asctime)s %(module)s %(process)d %(thread)d %(message)s'
         },
-        'splunk_format':{
-            'format': 'hostname={} level=%(levelname)s logger=%(name)s timestamp=%(asctime)s module=%(module)s process=%(process)d thread=%(thread)d message=%(message)s\n\r'.format(HOST_NAME)
+        'filebeat_format': {
+            'format': 'hostname={}|level=%(levelname)s|logger=%(name)s|timestamp=%(asctime)s|module=%(module)s|process=%(process)d|thread=%(thread)d|message=%(message)s'.format(HOST_NAME)
         }
     },
     'handlers': {
@@ -112,11 +112,11 @@ LOGGING = {
 }
 
 if FILEBEAT_HOST and FILEBEAT_PORT:
-    LOGGING['handlers']['splunk'] = {
+    LOGGING['handlers']['filebeat'] = {
         'level': os.environ.get('FILEBEAT_LOGGING_LEVEL', 'INFO'),
         'class': 'logging.handlers.SysLogHandler',
-        'formatter': 'splunk_format',
+        'formatter': 'filebeat_format',
         'address': (FILEBEAT_HOST, int(FILEBEAT_PORT))
     }
-    LOGGING['root']['handlers'].append('splunk')
-    LOGGING['loggers']['django.request']['handlers'].append('splunk')
+    LOGGING['root']['handlers'].append('filebeat')
+    LOGGING['loggers']['django.request']['handlers'].append('filebeat')

--- a/omaha_server/omaha_server/utils.py
+++ b/omaha_server/omaha_server/utils.py
@@ -47,7 +47,7 @@ def get_client_ip(request):
 
 
 def add_extra_to_log_message(msg, extra):
-    return msg + ' '.join(", %s=%s" % (key, val) for (key, val) in sorted(extra.items()))
+    return msg + '|'.join("%s=%s" % (key, val) for (key, val) in sorted(extra.items()))
 
 def get_splunk_url(params):
     SEARCH_TEMPLATE = 'http://%s/en-US/app/search/search?q=search %s'

--- a/pavement.py
+++ b/pavement.py
@@ -135,11 +135,16 @@ def configure_filebeat():
     filebeat_destination = os.environ.get('FILEBEAT_DESTINATION', '')
     filebeat_destination = filebeat_destination.lower()
     if filebeat_destination == 'elasticsearch' and elk_host and elk_port.isdigit():
+        configure_elasticsearch(elk_host, elk_port)
         elasticsearch_output(elk_host, elk_port)
     elif filebeat_destination == 'logstash' and elk_host and elk_port.isdigit():
         logstash_output(elk_host, elk_port)
     else:
         filename_output()
+
+def configure_elasticsearch(elk_host, elk_port):
+   filter_path = os.path.abspath("conf/standard_filter.json")
+   sh("curl -XPUT '%s:%s/_ingest/pipeline/standard_filter?pretty' -H 'Content-Type: application/json' -d @%s" % (elk_host, elk_port, filter_path))
 
 
 @task
@@ -152,7 +157,6 @@ def docker_run():
             loaddata()
             create_admin()
             collectstatic()
-
         configure_nginx()
         configure_filebeat()
         sh('/usr/bin/supervisord')


### PR DESCRIPTION
If you use Filebeat as a log aggregator, the messages are not divided by fields. Added a set of filters for Elasticsearch so that a log message is split up into separate fields.