### PR TITLE
Set AWS_DEFAULT_ACL to private

### DIFF
--- a/omaha_server/omaha_server/settings_prod.py
+++ b/omaha_server/omaha_server/settings_prod.py
@@ -26,7 +26,7 @@ S3_URL = 'https://%s.s3.amazonaws.com/' % AWS_STORAGE_BUCKET_NAME
 STATIC_URL = ''.join([S3_URL, 'static/'])
 AWS_PRELOAD_METADATA = True
 AWS_IS_GZIPPED = True
-AWS_DEFAULT_ACL = 'authenticated-read'
+AWS_DEFAULT_ACL = 'private'
 
 
 RAVEN_CONFIG = {


### PR DESCRIPTION
Note: This hasn't gotten much testing mainly because we don't use S3 backend currently.

This should fix https://github.com/Crystalnix/omaha-server/issues/321, however more testing is probably needed. I'll update this as I can with tests but any comments/thoughts would be appreciated since this seems like a fairly bad security issue.
